### PR TITLE
Fallback to correct default to

### DIFF
--- a/libs/e4QueryParser.php
+++ b/libs/e4QueryParser.php
@@ -127,7 +127,7 @@ class e4QueryParser
 				$this->to->setInput($this->parsed['to']);
 				if (!$this->to->parse())
 				{
-					if ($this->from->isEqualOf($this->defaultFrom))
+					if (!$this->from->isEqualOf($this->defaultTo))
 						$this->to = $this->defaultTo;
 					else
 						$this->to = $this->defaultFrom;


### PR DESCRIPTION
If _to_ is not set and _from_ equals _default from_ it uses _default to_ . It should fallback to _default to_ if _from_ is not equal to _default to_.

Example with _default to_ set to DKK and _default from_ set to EUR:

`currency 100 gbp` converts to euro, where it should convert to my _default to_.

A little confusing I must admit, but this should be the right pattern.
